### PR TITLE
Update for compatibility with omniauth-oauth2 1.4

### DIFF
--- a/lib/omniauth-bnet/version.rb
+++ b/lib/omniauth-bnet/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Bnet
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end

--- a/lib/omniauth/strategies/bnet.rb
+++ b/lib/omniauth/strategies/bnet.rb
@@ -54,6 +54,10 @@ module OmniAuth
 
       private
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       def getHost(region)
         case region
         when "cn"


### PR DESCRIPTION
As mentioned in intridea/omniauth-oauth2#81 and #3, version 1.4 of omniauth-oauth2 has an issue with query params being broken. Previously it overrode the callback_url, but now it no longer matches, causing all callbacks to fail.

This patch should fix the functionality to allow maximum compatibility with other versions. It's basically what many other strategy authors have done. Hope that helps!